### PR TITLE
Adding NDK API for PerformanceHintAPI

### DIFF
--- a/app/src/main/cpp/adpf_manager.cpp
+++ b/app/src/main/cpp/adpf_manager.cpp
@@ -30,28 +30,33 @@ void thermal_callback(void *data, AThermalStatus status) {
 }
 
 void nativeRegisterThermalStatusListener(JNIEnv *env, jclass cls) {
+#if __ANDROID_API__ >= 30
   auto manager = ADPFManager::getInstance().GetThermalManager();
   if (manager != nullptr) {
     auto ret = AThermal_registerThermalStatusListener(manager, thermal_callback,
                                                       nullptr);
     ALOGI("Thermal Status callback registerred to:%d", ret);
   }
+#endif
 }
 
 void nativeUnregisterThermalStatusListener(JNIEnv *env, jclass cls) {
+#if __ANDROID_API__ >= 30
   auto manager = ADPFManager::getInstance().GetThermalManager();
   if (manager != nullptr) {
     auto ret = AThermal_unregisterThermalStatusListener(
         manager, thermal_callback, nullptr);
     ALOGI("Thermal Status callback unregisterred to:%d", ret);
   }
+#endif
 }
 
 // Invoke the method periodically (once a frame) to monitor
 // the device's thermal throttling status.
 void ADPFManager::Monitor() {
-  float current_clock = Clock();
-  if (current_clock - last_clock_ >= kThermalHeadroomUpdateThreshold) {
+  auto current_clock = std::chrono::high_resolution_clock::now();
+  auto past = current_clock - last_clock_;
+  if (past >= kThermalHeadroomUpdateThreshold) {
     // Update thermal headroom.
     UpdateThermalStatusHeadRoom();
     last_clock_ = current_clock;
@@ -71,11 +76,13 @@ void ADPFManager::SetApplication(android_app *app) {
 
 // Initialize JNI calls for the powermanager.
 bool ADPFManager::InitializePowerManager() {
+#if __ANDROID_API__ >= 30
   if (android_get_device_api_level() >= 31) {
     // Initialize the powermanager using NDK API.
     thermal_manager_ = AThermal_acquireManager();
     return true;
   }
+#endif
 
   JNIEnv *env = NativeEngine::GetInstance()->GetJniEnv();
 
@@ -116,12 +123,15 @@ bool ADPFManager::InitializePowerManager() {
 
 // Retrieve current thermal headroom using JNI call.
 float ADPFManager::UpdateThermalStatusHeadRoom() {
+#if __ANDROID_API__ >= 31
   if (android_get_device_api_level() >= 31) {
     // Use NDK API to retrieve thermal status headroom.
+    auto seconds = kThermalHeadroomUpdateThreshold.count();
     thermal_headroom_ = AThermal_getThermalHeadroom(
-        thermal_manager_, kThermalHeadroomUpdateThreshold);
+        thermal_manager_, seconds);
     return thermal_headroom_;
   }
+#endif
 
   if (app_ == nullptr || get_thermal_headroom_ == 0) {
     return 0.f;
@@ -138,6 +148,21 @@ float ADPFManager::UpdateThermalStatusHeadRoom() {
 
 // Initialize JNI calls for the PowerHintManager.
 bool ADPFManager::InitializePerformanceHintManager() {
+#if __ANDROID_API__ >= 33
+    if ( hint_manager_ == nullptr ) {
+        hint_manager_ = APerformanceHint_getManager();
+    }
+    if ( hint_session_ == nullptr && hint_manager_ != nullptr ) {
+        int32_t tid = gettid();
+        thread_ids_.push_back(tid);
+        int32_t tids[1];
+        tids[0] = tid;
+        hint_session_ = APerformanceHint_createSession(hint_manager_, tids, 1, last_target_);
+    }
+    ALOGE("ADPFManager::InitializePerformanceHintManager __ANDROID_API__ 33");
+    return true;
+#else  
+  ALOGE("ADPFManager::InitializePerformanceHintManager __ANDROID_API__ < 33");
   JNIEnv *env = NativeEngine::GetInstance()->GetJniEnv();
 
   // Retrieve class information
@@ -159,7 +184,7 @@ bool ADPFManager::InitializePerformanceHintManager() {
 
   // Retrieve methods IDs for the APIs.
   jclass cls_perfhint_service = env->GetObjectClass(obj_perfhint_service_);
-  jmethodID mid_createhintsession =
+  create_hint_session_ =
       env->GetMethodID(cls_perfhint_service, "createHintSession",
                        "([IJ)Landroid/os/PerformanceHintManager$Session;");
   jmethodID mid_preferedupdaterate = env->GetMethodID(
@@ -167,13 +192,13 @@ bool ADPFManager::InitializePerformanceHintManager() {
 
   // Create int array which contain current tid.
   jintArray array = env->NewIntArray(1);
-  int32_t tid = getpid();
+  int32_t tid = gettid();
   env->SetIntArrayRegion(array, 0, 1, &tid);
   const jlong DEFAULT_TARGET_NS = 16666666;
 
   // Create Hint session for the thread.
   jobject obj_hintsession = env->CallObjectMethod(
-      obj_perfhint_service_, mid_createhintsession, array, DEFAULT_TARGET_NS);
+      obj_perfhint_service_, create_hint_session_, array, DEFAULT_TARGET_NS);
   if (obj_hintsession == nullptr) {
     ALOGI("Failed to create a perf hint session.");
   } else {
@@ -187,6 +212,8 @@ bool ADPFManager::InitializePerformanceHintManager() {
         cls_perfhint_session, "reportActualWorkDuration", "(J)V");
     update_target_work_duration_ = env->GetMethodID(
         cls_perfhint_session, "updateTargetWorkDuration", "(J)V");
+    set_threads_ = env->GetMethodID(
+        cls_perfhint_session, "setThreads", "([I)V");
   }
 
   // Free local references
@@ -203,6 +230,7 @@ bool ADPFManager::InitializePerformanceHintManager() {
   }
 
   return true;
+#endif // __ANDROID_API__ >= 33
 }
 
 thermalStateChangeListener ADPFManager::thermalListener = NULL;
@@ -223,12 +251,21 @@ void ADPFManager::SetThermalListener(thermalStateChangeListener listener) {
 // Indicates the start and end of the performance intensive task.
 // The methods call performance hint API to tell the performance
 // hint to the system.
-void ADPFManager::BeginPerfHintSession() { perfhintsession_start_ = Clock(); }
+void ADPFManager::BeginPerfHintSession() { 
+  perf_start_ = std::chrono::high_resolution_clock::now();
+}
 void ADPFManager::EndPerfHintSession(jlong target_duration_ns) {
+#if __ANDROID_API__ >= 33
+    auto perf_end = std::chrono::high_resolution_clock::now();
+    auto dur = std::chrono::duration_cast<std::chrono::nanoseconds>(perf_end - perf_start_).count();
+    int64_t actual_duration_ns = static_cast<int64_t>(dur);
+    APerformanceHint_reportActualWorkDuration(hint_session_, actual_duration_ns);
+    APerformanceHint_updateTargetWorkDuration(hint_session_, target_duration_ns);
+#else
   if (obj_perfhint_session_) {
-    auto current_clock = Clock();
-    auto duration = current_clock - perfhintsession_start_;
-    jlong duration_ns = duration * 100000000;
+    auto perf_end = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(perf_end - perf_start_).count();
+    int64_t duration_ns = static_cast<int64_t>(duration);
     JNIEnv *env = NativeEngine::GetInstance()->GetJniEnv();
 
     // Report and update the target work duration using JNI calls.
@@ -237,4 +274,55 @@ void ADPFManager::EndPerfHintSession(jlong target_duration_ns) {
     env->CallVoidMethod(obj_perfhint_session_, update_target_work_duration_,
                         target_duration_ns);
   }
+#endif // __ANDROID_API__ >= 33
+}
+
+void ADPFManager::AddThreadIdToHintSession(int32_t tid) {
+    thread_ids_.push_back(tid);
+
+    RegisterThreadIdsToHintSession();
+}
+
+void ADPFManager::RemoveThreadIdFromHintSession(int32_t tid) {
+    thread_ids_.erase(std::remove(thread_ids_.begin(), thread_ids_.end(), tid), thread_ids_.end());
+
+    RegisterThreadIdsToHintSession();
+}
+
+void ADPFManager::RegisterThreadIdsToHintSession() {
+#if __ANDROID_API__ >= 34
+    auto data = thread_ids_.data();
+    std::size_t size = thread_ids_.size();
+    APerformanceHint_setThreads(hint_session_, data, size);
+#elif __ANDROID_API__ >= 33
+    auto data = thread_ids_.data();
+    std::size_t size = thread_ids_.size();
+    if ( hint_session_ != nullptr ) {
+        APerformanceHint_closeSession(hint_session_);
+    }
+    hint_session_ = APerformanceHint_createSession(hint_manager_, data, size, last_target_);
+#else
+    JNIEnv *env = NativeEngine::GetInstance()->GetJniEnv();
+    std::size_t size = thread_ids_.size();
+    jintArray array = env->NewIntArray(size);
+    auto data = thread_ids_.data();
+    env->SetIntArrayRegion(array, 0, size, data);
+    if ( set_threads_ == nullptr ) {
+        // we have to recreate the hint session
+        if ( obj_perfhint_session_ ) {
+            env->DeleteGlobalRef(obj_perfhint_session_ );
+        }
+        const jlong DEFAULT_TARGET_NS = 16666666;
+        jobject obj_hintsession = env->CallObjectMethod(obj_perfhint_service_, create_hint_session_, array, DEFAULT_TARGET_NS);
+        obj_perfhint_session_ = env->NewGlobalRef(obj_hintsession);
+    } else {
+        // API Level 34
+        env->CallVoidMethod(obj_perfhint_session_, set_threads_, array);
+        jboolean check = env->ExceptionCheck();
+        if ( check ) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    }
+#endif
 }

--- a/app/src/main/cpp/adpf_manager.cpp
+++ b/app/src/main/cpp/adpf_manager.cpp
@@ -55,8 +55,8 @@ void nativeUnregisterThermalStatusListener(JNIEnv *env, jclass cls) {
 // the device's thermal throttling status.
 void ADPFManager::Monitor() {
   auto current_clock = std::chrono::high_resolution_clock::now();
-  auto past = current_clock - last_clock_;
-  if (past >= kThermalHeadroomUpdateThreshold) {
+  auto duration = current_clock - last_clock_;
+  if (duration >= kThermalHeadroomUpdateThreshold) {
     // Update thermal headroom.
     UpdateThermalStatusHeadRoom();
     last_clock_ = current_clock;
@@ -77,7 +77,7 @@ void ADPFManager::SetApplication(android_app *app) {
 // Initialize JNI calls for the powermanager.
 bool ADPFManager::InitializePowerManager() {
 #if __ANDROID_API__ >= 30
-  if (android_get_device_api_level() >= 31) {
+  if (android_get_device_api_level() >= 30) {
     // Initialize the powermanager using NDK API.
     thermal_manager_ = AThermal_acquireManager();
     return true;
@@ -142,7 +142,7 @@ float ADPFManager::UpdateThermalStatusHeadRoom() {
   thermal_headroom_ =
       env->CallFloatMethod(obj_power_service_, get_thermal_headroom_,
                            kThermalHeadroomUpdateThreshold);
-  ALOGE("Current thermal Headroom %f", thermal_headroom_);
+  ALOGI("Current thermal Headroom %f", thermal_headroom_);
   return thermal_headroom_;
 }
 
@@ -159,10 +159,10 @@ bool ADPFManager::InitializePerformanceHintManager() {
         tids[0] = tid;
         hint_session_ = APerformanceHint_createSession(hint_manager_, tids, 1, last_target_);
     }
-    ALOGE("ADPFManager::InitializePerformanceHintManager __ANDROID_API__ 33");
+    ALOGI("ADPFManager::InitializePerformanceHintManager __ANDROID_API__ 33");
     return true;
 #else  
-  ALOGE("ADPFManager::InitializePerformanceHintManager __ANDROID_API__ < 33");
+  ALOGD("ADPFManager::InitializePerformanceHintManager __ANDROID_API__ < 33");
   JNIEnv *env = NativeEngine::GetInstance()->GetJniEnv();
 
   // Retrieve class information

--- a/app/src/main/cpp/adpf_manager.h
+++ b/app/src/main/cpp/adpf_manager.h
@@ -33,14 +33,6 @@
 #include <unistd.h>
 #include <vector>
 
-    // #include <algorithm>
-    // #include <unistd.h>
-    // #include <chrono>
-    // #include <cstdio>
-    // #include <cstdlib>
-    // #include <cstring>
-    // #include <sstream>
-
 #include "common.h"
 #include "native_engine.h"
 #include "util.h"
@@ -71,10 +63,16 @@ class ADPFManager {
       if (obj_power_service_ != nullptr) {
         app_->activity->env->DeleteGlobalRef(obj_power_service_);
       }
-#if __ANDROID_API__ >= 33
-#elif __ANDROID_API >= 30
+
+#if __ANDROID_API >= 30
       if (thermal_manager_ != nullptr) {
         AThermal_releaseManager(thermal_manager_);
+      }
+#endif
+
+#if __ANDROID_API__ >= 33
+      if ( hint_session_ != nullptr ) {
+        APerformanceHint_closeSession(hint_session_);
       }
 #else
       if (obj_perfhint_service_ != nullptr) {


### PR DESCRIPTION
NDK APIs for PerformanceHintAPIs are available since API Level 33 onwards and they are a lot easier to use for game developers writing code in C/C++.

This PR added support for NDK APIs without breaking compatibility for apps targeting lower API Levels. If you are targeting lower API Levels, the NDK APIs may not be defined thus you'll have to use conditional compilation and use the Java APIs for the lower API Level devices. If you're only targeting API Level 33 and above, you can omit the conditional compilation and just use the NDK APIs